### PR TITLE
ci: fix auto-add secret name (ADD_TO_PROJECT)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,12 @@
+name: Add new issues to AusTraits board #9
+on:
+  issues:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/traitecoevo/projects/9
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT }}


### PR DESCRIPTION
Follow-up to #29. The merged workflow referenced `secrets.ADD_TO_PROJECT_PAT`, but the org secret is named `ADD_TO_PROJECT` — so the first run failed. This points it at the correct name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)