### PR TITLE
ci: revert auto-add secret name to ADD_TO_PROJECT_PAT

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
-          github-token: ${{ secrets.ADD_TO_PROJECT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,12 @@
+name: Add new issues to AusTraits board #9
+on:
+  issues:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/traitecoevo/projects/9
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT }}


### PR DESCRIPTION
Reverts the secret name back to `ADD_TO_PROJECT_PAT` — that is the name plant-family already uses (confirmed in `traitecoevo/plant`). #31 incorrectly renamed it to `ADD_TO_PROJECT`.

The real remaining step is making `ADD_TO_PROJECT_PAT` an **org-level** secret (currently it is only a repo secret on `plant`) so public repos can read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)