### PR TITLE
ci: fix auto-add secret name to ADD_TO_PROJECT_PAT

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
-          github-token: ${{ secrets.ADD_TO_PROJECT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Restores the correct secret name `ADD_TO_PROJECT_PAT` on master (#31 had renamed it to `ADD_TO_PROJECT`, which does not exist). This is the name plant-family already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)