### PR TITLE
Add AusTraits family page and embedded data portal

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -14,6 +14,8 @@ website:
         text: Platform
       - href: index.html#access
         text: Access
+      - href: portal.qmd
+        text: Data portal
       - href: index.html#software
         text: Tools
       - text: About

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,6 +18,8 @@ website:
         text: Tools
       - text: About
         menu:
+          - href: family.qmd
+            text: The family
           - href: team/team-partners.qmd
             text: Team
           - href: history.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,10 +20,10 @@ website:
         text: Tools
       - text: About
         menu:
-          - href: family.qmd
-            text: The family
           - href: team/team-partners.qmd
             text: Team
+          - href: family.qmd
+            text: The family
           - href: history.qmd
             text: History
           - href: impact.qmd

--- a/family.qmd
+++ b/family.qmd
@@ -20,6 +20,7 @@ flowchart TD
   ZEN[("Zenodo<br/>austraits-X.Y.Z")]
   PKG["<b>austraits</b><br/>R access &amp; wrangling"]
   WEB["Data portal &amp; API<br/>code-free access"]
+  REUSE["reused beyond AusTraits<br/>(other trait databases<br/>&amp; taxonomy projects)"]
 
   APD --> BUILD
   APC --> BUILD
@@ -28,11 +29,15 @@ flowchart TD
   BUILD --> ZEN
   ZEN --> PKG
   ZEN --> WEB
+  APC -. reused by .-> REUSE
+  TB -. reused by .-> REUSE
 
   classDef core fill:#e8f4ec,stroke:#4a8a68,color:#1d3b2a;
   classDef data fill:#eef2f7,stroke:#7089a8,color:#243044;
+  classDef reuse fill:#fbf6ea,stroke:#c9a340,color:#5b4a12,stroke-dasharray:4 3;
   class APD,APC,TB,BUILD,PKG core;
   class RAW,ZEN,WEB data;
+  class REUSE reuse;
 ```
 
 A key subtlety: the **data flow** above is not the same as the R-package install graph. In the build,
@@ -51,7 +56,7 @@ lives in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta).
   </article>
   <article class="plain-card">
     <h3>APCalign — taxonomy alignment</h3>
-    <p>Aligns and updates plant names against the Australian Plant Census / APNI, and reports native vs introduced status. Used to standardise taxonomy before data is compiled.</p>
+    <p>Aligns and updates plant names against the Australian Plant Census / APNI, and reports native vs introduced status. Used to standardise taxonomy before data is compiled — and reusable as a standalone taxonomy tool in any other project.</p>
     <p><a href="https://traitecoevo.github.io/APCalign/" target="_blank" rel="noopener">Package site</a></p>
   </article>
   <article class="plain-card">

--- a/family.qmd
+++ b/family.qmd
@@ -1,0 +1,121 @@
+---
+title: "The AusTraits family"
+---
+
+AusTraits is not a single product but a **family** of connected open-source tools, datasets, and
+vocabularies. Each piece does one job well and hands off to the next: a controlled vocabulary defines
+the traits, a taxonomy tool standardises the names, a workflow engine harmonises contributed data into
+a single database, and an R package plus web tools let anyone access it. This page shows how the pieces
+fit together and where to go for each.
+
+## How the pieces connect
+
+```{mermaid}
+flowchart TD
+  APD["<b>APD</b><br/>trait vocabulary<br/>(definitions, units, allowed values)"]
+  APC["<b>APCalign</b><br/>taxonomy alignment<br/>(APC / APNI)"]
+  RAW["contributed<br/>source datasets"]
+  TB["<b>traits.build</b><br/>workflow engine<br/>+ data model"]
+  BUILD["<b>austraits.build</b><br/>the AusTraits<br/>dataset compilation"]
+  ZEN[("Zenodo<br/>austraits-X.Y.Z")]
+  PKG["<b>austraits</b><br/>R access &amp; wrangling"]
+  WEB["Data portal &amp; API<br/>code-free access"]
+
+  APD --> BUILD
+  APC --> BUILD
+  RAW --> BUILD
+  TB -. engine .-> BUILD
+  BUILD --> ZEN
+  ZEN --> PKG
+  ZEN --> WEB
+
+  classDef core fill:#e8f4ec,stroke:#4a8a68,color:#1d3b2a;
+  classDef data fill:#eef2f7,stroke:#7089a8,color:#243044;
+  class APD,APC,TB,BUILD,PKG core;
+  class RAW,ZEN,WEB data;
+```
+
+A key subtlety: the **data flow** above is not the same as the R-package install graph. In the build,
+`traits.build` is the engine that assembles `austraits.build`; but as R packages, `traits.build`
+actually depends on a few helpers from `austraits`. The authoritative, up-to-date map of both graphs
+lives in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta).
+
+## The core pipeline
+
+```{=html}
+<div class="card-grid">
+  <article class="plain-card">
+    <h3>APD — AusTraits Plant Dictionary</h3>
+    <p>The trait <strong>vocabulary</strong>: definitions, allowed categorical values, units, and links to other trait databases. Everything downstream conforms to it.</p>
+    <p><a href="https://w3id.org/APD" target="_blank" rel="noopener">w3id.org/APD</a> · <a href="https://github.com/traitecoevo/APD" target="_blank" rel="noopener">source</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>APCalign — taxonomy alignment</h3>
+    <p>Aligns and updates plant names against the Australian Plant Census / APNI, and reports native vs introduced status. Used to standardise taxonomy before data is compiled.</p>
+    <p><a href="https://traitecoevo.github.io/APCalign/" target="_blank" rel="noopener">Package site</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>traits.build — the workflow engine</h3>
+    <p>A general-purpose data model and R workflow for harmonising trait data into a documented, relational structure. AusTraits is built with it — and so can any other trait database.</p>
+    <p><a href="https://traitecoevo.github.io/traits.build/" target="_blank" rel="noopener">Package site</a> · <a href="https://traitecoevo.github.io/traits.build-book/" target="_blank" rel="noopener">User manual</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>austraits.build — the dataset compilation</h3>
+    <p>Wires the vocabulary (APD), taxonomy (APCalign), and the engine (traits.build) together over hundreds of contributed source datasets to produce the released AusTraits database.</p>
+    <p><a href="https://github.com/traitecoevo/austraits.build" target="_blank" rel="noopener">Repository</a> · <a href="https://doi.org/10.5281/zenodo.3568417" target="_blank" rel="noopener">Zenodo releases</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>austraits — access &amp; wrangling</h3>
+    <p>The R package for loading, filtering, joining, reshaping, and plotting AusTraits (and any traits.build database) once it has been compiled and released.</p>
+    <p><a href="https://traitecoevo.github.io/austraits/" target="_blank" rel="noopener">Package site</a></p>
+  </article>
+</div>
+```
+
+## Tools &amp; interfaces
+
+```{=html}
+<div class="card-grid">
+  <article class="plain-card">
+    <h3>AusTraits data portal</h3>
+    <p>A code-free, point-and-click interface to browse, filter, and download AusTraits data in the browser — no R required.</p>
+    <p><a href="https://app.austraits.org/austraits/" target="_blank" rel="noopener">Open the portal</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>AusTraits API</h3>
+    <p>An HTTP API layer over the AusTraits access functions, for programmatic access from any language.</p>
+    <p><a href="https://github.com/traitecoevo/austraits-api" target="_blank" rel="noopener">Repository</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>APCalign app</h3>
+    <p>A browser app for aligning and updating plant name lists against the APC — the APCalign workflow, without writing code.</p>
+    <p><a href="https://app.austraits.org/APCalign-app/" target="_blank" rel="noopener">Open the app</a></p>
+  </article>
+</div>
+```
+
+## Documentation &amp; governance
+
+```{=html}
+<div class="card-grid">
+  <article class="plain-card">
+    <h3>traits.build book</h3>
+    <p>The user manual for the data standard, the R package, and the workflow — including tutorials for adding data and using outputs.</p>
+    <p><a href="https://traitecoevo.github.io/traits.build-book/" target="_blank" rel="noopener">Read the book</a></p>
+  </article>
+  <article class="plain-card">
+    <h3>austraits-meta</h3>
+    <p>The family's cross-package knowledge and governance hub: the dependency map, source-of-truth rules, the shared issue board, and release playbooks.</p>
+    <p><a href="https://github.com/traitecoevo/austraits-meta" target="_blank" rel="noopener">Governance hub</a></p>
+  </article>
+</div>
+```
+
+## How to cite
+
+If you use AusTraits or its tools, please cite the relevant paper:
+
+- **AusTraits dataset** — Falster *et al.* (2021) *Scientific Data* 8:254. [10.1038/s41597-021-01006-6](https://doi.org/10.1038/s41597-021-01006-6)
+- **traits.build** — Wenk *et al.* (2024) *Ecological Informatics* 83:102773. [10.1016/j.ecoinf.2024.102773](https://doi.org/10.1016/j.ecoinf.2024.102773)
+- **AusTraits Plant Dictionary (APD)** — Wenk *et al.* (2024) *Scientific Data* 11:537. [10.1038/s41597-024-03368-z](https://doi.org/10.1038/s41597-024-03368-z)
+- **APCalign** — Wenk *et al.* (2024) *Australian Journal of Botany* 72:BT24014. [10.1071/BT24014](https://doi.org/10.1071/BT24014)

--- a/index.qmd
+++ b/index.qmd
@@ -128,13 +128,11 @@ execute:
         <h3>ALA integration</h3>
         <p>Access taxon-level trait summaries through Atlas of Living Australia pages.</p>
       </a>
-      <!-- TODO: add a panel for the data portal once the URL is confirmed
-      <a class="resource-card" href="DATA_PORTAL_URL" target="_blank" rel="noopener">
+      <a class="resource-card" href="portal.html">
         <span class="card-icon"><i class="bi bi-window-stack"></i></span>
         <h3>Data portal</h3>
-        <p>Browse, filter, and query AusTraits data interactively in the browser.</p>
+        <p>Browse, filter, and download AusTraits data interactively in the browser — no code required.</p>
       </a>
-      -->
     </div>
   </div>
 </section>

--- a/index.qmd
+++ b/index.qmd
@@ -192,6 +192,7 @@ execute:
         </div>
       </article>
     </div>
+    <p class="section-intro"><a href="family.html">See how these tools fit together in the AusTraits family →</a></p>
   </div>
 </section>
 

--- a/portal.qmd
+++ b/portal.qmd
@@ -1,0 +1,33 @@
+---
+title: "AusTraits data portal"
+format:
+  html:
+    page-layout: full
+    toc: false
+---
+
+The AusTraits data portal is a code-free, point-and-click interface for browsing, filtering, and
+downloading AusTraits data — no R or programming required. It is embedded below, or you can
+
+<p>
+<a class="btn-primary" href="https://app.austraits.org/austraits/" target="_blank" rel="noopener"><i class="bi bi-box-arrow-up-right"></i> Open the portal in a new tab</a>
+</p>
+
+```{=html}
+<div style="position: relative; width: 100%; height: 80vh; min-height: 600px; border: 1px solid #ddd; border-radius: 6px; overflow: hidden; margin-top: 1rem;">
+  <iframe
+    src="https://app.austraits.org/austraits/"
+    title="AusTraits data portal"
+    loading="lazy"
+    allowfullscreen
+    style="width: 100%; height: 100%; border: none;">
+  </iframe>
+</div>
+```
+
+::: {.callout-note appearance="simple"}
+The portal is hosted on AWS at [app.austraits.org](https://app.austraits.org/austraits/). For
+programmatic access to the same data, use the [`austraits`](https://traitecoevo.github.io/austraits/)
+R package. Source code for the portal lives in
+[`traitecoevo/austraits.portal`](https://github.com/traitecoevo/austraits.portal).
+:::

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,14 @@
   --at-white: #ffffff;
   --at-shadow: 0 10px 26px rgba(30, 45, 38, 0.08);
   --at-radius: 8px;
+
+  /* Quarto derives the mermaid edge colour from the simplex theme, which
+     resolves to white — invisible arrows/labels on our white pages. Pin it
+     to a legible neutral so flowchart edges and edge labels show. The label
+     foreground otherwise inherits the simplex primary (red), which reads as an
+     error on a flow diagram — pin it to the same neutral. */
+  --mermaid-edge-color: #64726b;
+  --mermaid-label-fg-color: #4a544e;
 }
 
 body {
@@ -654,7 +662,8 @@ main.content {
 }
 
 .plain-card a {
-  font-weight: 600;
+  font-size: 0.82rem;
+  font-weight: 500;
 }
 
 .data-product-panel {


### PR DESCRIPTION
Two additions to make the ecosystem and the live portal discoverable on the site:

**The AusTraits family** (`family.qmd`) — explains how the family fits together (APD → APCalign → traits.build → austraits.build → austraits → portal/API) with a pipeline diagram, per-component cards, and a how-to-cite list. Under the **About** menu; front page gets a single teaser link.

**Data portal** (`portal.qmd`) — embeds the AWS-hosted portal (`app.austraits.org/austraits`) via an iframe with an open-in-new-tab link; added to the navbar and activates the data-portal card in the **Access** section (previously commented out).

Both render locally (`quarto render`). This PR builds a Netlify **deploy-preview** only; production deploys on push to `master`. Part of the family usability work (`traitecoevo/austraits-meta` → `plans/family-usability-overhaul.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)